### PR TITLE
Implement CNN-based COP solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,124 @@
-# socom-ignite-COP
-A software solution integrating AI-driven common operating picture (COP) generation
+# SOCOM Ignite Common Operating Picture CNN
+
+This repository contains a reference implementation of an AI-enabled common operating picture (COP) generator driven by a convolutional neural network (CNN). The system is designed to ingest heterogeneous imagery, fuse mission metadata, and deliver actionable classifications that accelerate staff decision cycles and reduce manual triage effort.
+
+## Key Capabilities
+
+- **Multi-source data integration** – Unified dataset abstraction handles imagery tiles alongside geospatial/temporal metadata to support AI-enabled COP workflows.
+- **Mission-ready CNN architecture** – Lightweight convolutional backbone fuses visual features and mission metadata for responsive inference in tactical environments.
+- **End-to-end pipeline** – Utilities for synthetic data generation, training, validation, and deployment-ready inference.
+- **Human-centric insights** – Metadata fusion and configurable class labels enable alignment with human analyst workflows and mission semantics.
+
+## Getting Started
+
+### Prerequisites
+
+Install dependencies into your Python environment (Python 3.9+ recommended):
+
+```bash
+pip install -r requirements.txt
+```
+
+### Generate a Synthetic Dataset
+
+Synthetic samples emulate UAV or satellite captures and allow rapid experimentation without sensitive data:
+
+```python
+from pathlib import Path
+from cop_cnn.data import generate_synthetic_samples
+
+generate_synthetic_samples(Path("dataset"), num_classes=4, samples_per_class=50)
+```
+
+The generator produces the directory layout expected by the dataset loader:
+
+```
+dataset/
+  class_0/
+    sample_0.png
+    sample_0.json
+  class_1/
+  ...
+```
+
+### Train the Model
+
+Use the training configuration dataclass to tailor the pipeline for your mission dataset. The example below trains for a single epoch on the synthetic data:
+
+```python
+from pathlib import Path
+from cop_cnn.train import TrainingConfig, train_model
+
+config = TrainingConfig(
+    data_dir=Path("dataset"),
+    num_classes=4,
+    metadata_dim=3,
+    image_size=(128, 128),
+    batch_size=16,
+    epochs=5,
+)
+
+model = train_model(config)
+```
+
+Model checkpoints are stored in `artifacts/` by default and include the highest performing validation model.
+
+### Run Inference
+
+Load trained weights and execute predictions against new imagery tiles:
+
+```python
+import torch
+from cop_cnn.inference import COPInferenceEngine
+from cop_cnn.data import metadata_to_tensor, COPSampleMetadata
+from datetime import datetime
+
+engine = COPInferenceEngine(
+    weights_path="artifacts/best_model.pt",
+    class_names=["safe", "needs_review", "priority"],
+    metadata_dim=3,
+)
+
+metadata = metadata_to_tensor(
+    COPSampleMetadata(
+        latitude=30.1,
+        longitude=45.2,
+        timestamp=datetime.utcnow(),
+        source="UAV-EO",
+    )
+)
+
+result = engine.predict("path/to/image.png", metadata=metadata)
+print(result)
+```
+
+## Testing
+
+Run the automated tests to validate the training and inference stack:
+
+```bash
+pytest
+```
+
+## Project Structure
+
+```
+src/cop_cnn/
+  __init__.py          # Package exports
+  data.py              # Dataset, metadata handling, synthetic generator
+  model.py             # CNN architecture and utilities
+  train.py             # Training loop and configuration
+  inference.py         # Model loading and inference helpers
+requirements.txt       # Core dependencies
+README.md              # Project overview and usage
+```
+
+## Extending the System
+
+- Integrate operational data feeds by subclassing `COPDataset` or enriching metadata encodings.
+- Add explainability modules (Grad-CAM, saliency maps) to support analyst trust.
+- Deploy the inference engine inside edge compute nodes for low-latency COP updates.
+
+## License
+
+This project is released under the MIT license.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch>=2.0.0
+torchvision>=0.15.0
+Pillow>=9.0.0

--- a/src/cop_cnn/__init__.py
+++ b/src/cop_cnn/__init__.py
@@ -1,0 +1,15 @@
+"""Top-level package for the SOCOM Ignite common operating picture CNN system."""
+
+from .model import COPCNN
+from .train import TrainingConfig, train_model
+from .inference import COPInferenceEngine
+from .data import COPDataset, generate_synthetic_samples
+
+__all__ = [
+    "COPCNN",
+    "TrainingConfig",
+    "train_model",
+    "COPInferenceEngine",
+    "COPDataset",
+    "generate_synthetic_samples",
+]

--- a/src/cop_cnn/data.py
+++ b/src/cop_cnn/data.py
@@ -1,0 +1,192 @@
+"""Data ingestion utilities for the COP convolutional neural network system."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class COPSampleMetadata:
+    """Structured metadata describing a single sample.
+
+    Attributes
+    ----------
+    latitude: float
+        Latitude of the sample centre in decimal degrees.
+    longitude: float
+        Longitude of the sample centre in decimal degrees.
+    timestamp: datetime
+        Timestamp associated with the intelligence collection.
+    source: str
+        Sensor modality identifier (e.g., "UAV-EO", "SAR").
+    analyst_notes: Optional[str]
+        Optional notes collected during manual exploitation.
+    """
+
+    latitude: float
+    longitude: float
+    timestamp: datetime
+    source: str
+    analyst_notes: Optional[str] = None
+
+
+class COPDataset(Dataset):
+    """Dataset representing COP tiles with metadata and mission labels.
+
+    The dataset expects a directory structure where each label corresponds to a
+    sub-folder. Metadata (geolocation, capture time, etc.) for each image can be
+    optionally provided via a JSON side-car file with the same stem as the image.
+    """
+
+    def __init__(
+        self,
+        root: Path | str,
+        transform: Optional[Callable[[Image.Image], torch.Tensor]] = None,
+        metadata_transform: Optional[Callable[[COPSampleMetadata], torch.Tensor]] = None,
+    ) -> None:
+        self.root = Path(root)
+        if not self.root.exists():
+            raise FileNotFoundError(f"Dataset root '{self.root}' does not exist.")
+        self.transform = transform
+        self.metadata_transform = metadata_transform
+        self.samples: List[Tuple[Path, int]] = []
+        self.class_to_idx: Dict[str, int] = {}
+
+        self._scan()
+
+    def _scan(self) -> None:
+        """Scan the directory tree and populate samples."""
+
+        for class_idx, class_dir in enumerate(sorted(p for p in self.root.iterdir() if p.is_dir())):
+            self.class_to_idx[class_dir.name] = class_idx
+            for image_path in sorted(class_dir.glob("*.jpg")):
+                self.samples.append((image_path, class_idx))
+            for image_path in sorted(class_dir.glob("*.png")):
+                self.samples.append((image_path, class_idx))
+
+        if not self.samples:
+            raise RuntimeError(
+                "No image samples were discovered. Ensure the dataset is organised as root/class_name/image.(jpg|png)."
+            )
+
+    def _load_metadata(self, image_path: Path) -> Optional[COPSampleMetadata]:
+        meta_path = image_path.with_suffix(".json")
+        if not meta_path.exists():
+            return None
+        with meta_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        try:
+            timestamp = datetime.fromisoformat(payload["timestamp"])
+        except (KeyError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid timestamp metadata in {meta_path}.") from exc
+        return COPSampleMetadata(
+            latitude=float(payload.get("latitude", 0.0)),
+            longitude=float(payload.get("longitude", 0.0)),
+            timestamp=timestamp,
+            source=payload.get("source", "unknown"),
+            analyst_notes=payload.get("analyst_notes"),
+        )
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+        image_path, label_idx = self.samples[index]
+        image = Image.open(image_path).convert("RGB")
+        if self.transform:
+            image_tensor = self.transform(image)
+        else:  # pragma: no cover - executed in production but not tests
+            image_tensor = torch.from_numpy(torch.ByteTensor(torch.ByteStorage.from_buffer(image.tobytes())).float())
+            image_tensor = image_tensor.view(image.size[1], image.size[0], 3).permute(2, 0, 1) / 255.0
+
+        metadata = self._load_metadata(image_path)
+        metadata_tensor: Optional[torch.Tensor] = None
+        if metadata and self.metadata_transform:
+            metadata_tensor = self.metadata_transform(metadata)
+        elif metadata:
+            metadata_tensor = torch.tensor(
+                [metadata.latitude, metadata.longitude], dtype=torch.float32
+            )  # simple default encoding
+
+        return {
+            "image": image_tensor,
+            "label": torch.tensor(label_idx, dtype=torch.long),
+            "metadata": metadata_tensor,
+            "path": str(image_path),
+        }
+
+
+def generate_synthetic_samples(
+    destination: Path | str,
+    num_classes: int = 3,
+    samples_per_class: int = 20,
+    image_size: Tuple[int, int] = (64, 64),
+    seed: Optional[int] = 17,
+) -> None:
+    """Generate a synthetic dataset composed of abstract shapes.
+
+    This utility enables rapid experimentation when real mission imagery is not
+    accessible in the development environment. The generated dataset supports the
+    same directory layout expected by :class:`COPDataset`.
+    """
+
+    rng = random.Random(seed)
+    destination_path = Path(destination)
+    destination_path.mkdir(parents=True, exist_ok=True)
+
+    for class_idx in range(num_classes):
+        class_dir = destination_path / f"class_{class_idx}"
+        class_dir.mkdir(exist_ok=True)
+        for sample_idx in range(samples_per_class):
+            image = Image.new("RGB", image_size, color=(0, 0, 0))
+            pixels = image.load()
+            centre_x = rng.randint(10, image_size[0] - 10)
+            centre_y = rng.randint(10, image_size[1] - 10)
+            radius = rng.randint(5, min(image_size) // 2)
+            color = (
+                rng.randint(0, 255),
+                rng.randint(0, 255),
+                rng.randint(0, 255),
+            )
+            for x in range(image_size[0]):
+                for y in range(image_size[1]):
+                    if (x - centre_x) ** 2 + (y - centre_y) ** 2 <= radius**2:
+                        pixels[x, y] = color
+            image_path = class_dir / f"sample_{sample_idx}.png"
+            image.save(image_path)
+
+            metadata = {
+                "latitude": rng.uniform(-90, 90),
+                "longitude": rng.uniform(-180, 180),
+                "timestamp": datetime.utcnow().isoformat(),
+                "source": rng.choice(["UAV-EO", "UAV-IR", "SAT-SAR"]),
+                "analyst_notes": "Synthetic sample",
+            }
+            with image_path.with_suffix(".json").open("w", encoding="utf-8") as handle:
+                json.dump(metadata, handle)
+
+
+def metadata_to_tensor(metadata: COPSampleMetadata) -> torch.Tensor:
+    """Encode metadata into a numeric tensor suitable for model conditioning."""
+
+    timestamp_feature = metadata.timestamp.timestamp() / (60 * 60 * 24)  # days since epoch
+    return torch.tensor(
+        [metadata.latitude, metadata.longitude, timestamp_feature], dtype=torch.float32
+    )
+
+
+__all__ = [
+    "COPDataset",
+    "COPSampleMetadata",
+    "generate_synthetic_samples",
+    "metadata_to_tensor",
+]

--- a/src/cop_cnn/inference.py
+++ b/src/cop_cnn/inference.py
@@ -1,0 +1,84 @@
+"""Inference utilities for deploying the COP CNN."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+import torch
+from PIL import Image
+from torchvision import transforms
+
+from .model import COPCNN
+
+
+class COPInferenceEngine:
+    """High-level interface for running inference on imagery tiles."""
+
+    def __init__(
+        self,
+        weights_path: Path | str,
+        class_names: Sequence[str],
+        metadata_dim: int = 0,
+        image_size: tuple[int, int] = (128, 128),
+        device: Optional[str] = None,
+    ) -> None:
+        self.device = torch.device(device) if device else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.class_names = list(class_names)
+        self.transforms = transforms.Compose(
+            [
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+            ]
+        )
+        self.model = COPCNN(num_classes=len(self.class_names), metadata_dim=metadata_dim)
+        state_dict = torch.load(weights_path, map_location=self.device)
+        self.model.load_state_dict(state_dict)
+        self.model.to(self.device)
+        self.model.eval()
+
+    def _prepare_image(self, image: Image.Image) -> torch.Tensor:
+        return self.transforms(image).unsqueeze(0).to(self.device)
+
+    def _prepare_metadata(self, metadata: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        if metadata is None:
+            return None
+        if metadata.dim() == 1:
+            metadata = metadata.unsqueeze(0)
+        return metadata.to(self.device)
+
+    def predict(self, image_path: Path | str, metadata: Optional[torch.Tensor] = None) -> dict:
+        """Predict the mission label for a single image path."""
+
+        with Image.open(image_path).convert("RGB") as image:
+            image_tensor = self._prepare_image(image)
+        metadata_tensor = self._prepare_metadata(metadata)
+        with torch.no_grad():
+            logits = self.model(image_tensor, metadata_tensor)
+            probabilities = torch.softmax(logits, dim=1)
+        top_prob, top_idx = probabilities.max(dim=1)
+        return {
+            "label": self.class_names[top_idx.item()],
+            "confidence": top_prob.item(),
+            "probabilities": {
+                name: probabilities[0, idx].item() for idx, name in enumerate(self.class_names)
+            },
+        }
+
+    def predict_batch(
+        self, image_paths: Iterable[Path | str], metadata: Optional[Iterable[Optional[torch.Tensor]]] = None
+    ) -> List[dict]:
+        paths = list(image_paths)
+        if metadata is None:
+            metadata_list = [None] * len(paths)
+        else:
+            metadata_list = list(metadata)
+            if len(metadata_list) != len(paths):
+                raise ValueError("Metadata length must match number of image paths.")
+        results: List[dict] = []
+        for path, meta in zip(paths, metadata_list):
+            results.append(self.predict(path, meta))
+        return results
+
+
+__all__ = ["COPInferenceEngine"]

--- a/src/cop_cnn/model.py
+++ b/src/cop_cnn/model.py
@@ -1,0 +1,91 @@
+"""Convolutional neural network backbone for common operating picture generation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+class ConvBlock(nn.Module):
+    """Utility module composed of convolution, batch normalisation and activation."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int = 3, stride: int = 1) -> None:
+        super().__init__()
+        padding = kernel_size // 2
+        self.block = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=kernel_size, stride=stride, padding=padding, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - wrapper
+        return self.block(x)
+
+
+class COPCNN(nn.Module):
+    """A lightweight CNN that fuses imagery with mission metadata."""
+
+    def __init__(self, in_channels: int = 3, num_classes: int = 3, metadata_dim: int = 0) -> None:
+        super().__init__()
+        self.metadata_dim = metadata_dim
+
+        self.stem = nn.Sequential(
+            ConvBlock(in_channels, 32, kernel_size=5, stride=2),
+            ConvBlock(32, 64),
+            nn.MaxPool2d(kernel_size=2),
+            ConvBlock(64, 128),
+            ConvBlock(128, 128),
+            nn.MaxPool2d(kernel_size=2),
+            ConvBlock(128, 256),
+        )
+
+        self.global_pool = nn.AdaptiveAvgPool2d((1, 1))
+        metadata_features = 0
+        if metadata_dim > 0:
+            self.metadata_encoder = nn.Sequential(
+                nn.Linear(metadata_dim, 64),
+                nn.ReLU(inplace=True),
+                nn.Dropout(p=0.1),
+                nn.Linear(64, 64),
+                nn.ReLU(inplace=True),
+            )
+            metadata_features = 64
+        else:
+            self.metadata_encoder = None
+
+        combined_features = 256 + metadata_features
+        self.classifier = nn.Sequential(
+            nn.Linear(combined_features, 128),
+            nn.ReLU(inplace=True),
+            nn.Dropout(p=0.3),
+            nn.Linear(128, num_classes),
+        )
+
+    def forward(self, image: torch.Tensor, metadata: Optional[torch.Tensor] = None) -> torch.Tensor:
+        visual_features = self.global_pool(self.stem(image)).flatten(1)
+        if self.metadata_dim > 0 and metadata is not None:
+            meta_features = self.metadata_encoder(metadata)
+            fused = torch.cat([visual_features, meta_features], dim=1)
+        else:
+            fused = visual_features
+        logits = self.classifier(fused)
+        return logits
+
+    def compute_loss(self, batch: dict, criterion: Optional[nn.Module] = None) -> torch.Tensor:
+        """Compute the training loss for a batch dictionary."""
+
+        if criterion is None:
+            criterion = nn.CrossEntropyLoss()
+        logits = self.forward(batch["image"], batch.get("metadata"))
+        return criterion(logits, batch["label"])
+
+    def freeze_backbone(self) -> None:
+        """Freeze convolutional layers to fine-tune metadata fusion head."""
+
+        for param in self.stem.parameters():
+            param.requires_grad = False
+
+
+__all__ = ["COPCNN", "ConvBlock"]

--- a/src/cop_cnn/train.py
+++ b/src/cop_cnn/train.py
@@ -1,0 +1,164 @@
+"""Training utilities for the COP CNN."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from torch.utils.data import DataLoader, random_split
+from torchvision import transforms
+
+from .data import COPDataset, metadata_to_tensor
+from .model import COPCNN
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration dataclass controlling model training."""
+
+    data_dir: Path
+    num_classes: int
+    metadata_dim: int = 0
+    image_size: Tuple[int, int] = (128, 128)
+    batch_size: int = 16
+    epochs: int = 10
+    learning_rate: float = 1e-3
+    weight_decay: float = 1e-4
+    validation_split: float = 0.2
+    num_workers: int = 0
+    output_dir: Path = Path("artifacts")
+    device: Optional[str] = None
+    log_interval: int = 10
+    seed: int = 42
+
+    def resolve_device(self) -> torch.device:
+        if self.device:
+            return torch.device(self.device)
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _build_transforms(image_size: Tuple[int, int]) -> transforms.Compose:
+    return transforms.Compose(
+        [
+            transforms.Resize(image_size),
+            transforms.ColorJitter(brightness=0.1, contrast=0.1),
+            transforms.ToTensor(),
+        ]
+    )
+
+
+def _prepare_dataloaders(config: TrainingConfig) -> tuple[DataLoader, Optional[DataLoader]]:
+    transform = _build_transforms(config.image_size)
+    dataset = COPDataset(
+        config.data_dir,
+        transform=transform,
+        metadata_transform=metadata_to_tensor if config.metadata_dim > 0 else None,
+    )
+    val_loader: Optional[DataLoader] = None
+    if 0 < config.validation_split < 1:
+        val_size = int(len(dataset) * config.validation_split)
+        train_size = len(dataset) - val_size
+        generator = torch.Generator().manual_seed(config.seed)
+        train_dataset, val_dataset = random_split(dataset, [train_size, val_size], generator=generator)
+        train_loader = DataLoader(
+            train_dataset,
+            batch_size=config.batch_size,
+            shuffle=True,
+            num_workers=config.num_workers,
+            pin_memory=True,
+        )
+        val_loader = DataLoader(
+            val_dataset,
+            batch_size=config.batch_size,
+            shuffle=False,
+            num_workers=config.num_workers,
+            pin_memory=True,
+        )
+    else:
+        train_loader = DataLoader(
+            dataset,
+            batch_size=config.batch_size,
+            shuffle=True,
+            num_workers=config.num_workers,
+            pin_memory=True,
+        )
+    return train_loader, val_loader
+
+
+def _move_batch_to_device(batch: dict, device: torch.device) -> dict:
+    batch = batch.copy()
+    batch["image"] = batch["image"].to(device)
+    batch["label"] = batch["label"].to(device)
+    if batch.get("metadata") is not None:
+        batch["metadata"] = batch["metadata"].to(device)
+    return batch
+
+
+def _evaluate(model: COPCNN, data_loader: DataLoader, device: torch.device) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for batch in data_loader:
+            batch = _move_batch_to_device(batch, device)
+            logits = model(batch["image"], batch.get("metadata"))
+            predictions = logits.argmax(dim=1)
+            correct += (predictions == batch["label"]).sum().item()
+            total += batch["label"].numel()
+    return correct / max(total, 1)
+
+
+def train_model(config: TrainingConfig) -> COPCNN:
+    """Train a :class:`COPCNN` using the provided configuration."""
+
+    torch.manual_seed(config.seed)
+    device = config.resolve_device()
+    train_loader, val_loader = _prepare_dataloaders(config)
+
+    model = COPCNN(num_classes=config.num_classes, metadata_dim=config.metadata_dim)
+    model.to(device)
+
+    optimizer = AdamW(model.parameters(), lr=config.learning_rate, weight_decay=config.weight_decay)
+    scheduler = CosineAnnealingLR(optimizer, T_max=config.epochs)
+    criterion = nn.CrossEntropyLoss()
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    best_val_accuracy = 0.0
+
+    for epoch in range(1, config.epochs + 1):
+        model.train()
+        running_loss = 0.0
+        for step, batch in enumerate(train_loader, start=1):
+            batch = _move_batch_to_device(batch, device)
+            loss = model.compute_loss(batch, criterion)
+            optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), max_norm=5.0)
+            optimizer.step()
+
+            running_loss += loss.item()
+            if step % config.log_interval == 0:
+                avg_loss = running_loss / config.log_interval
+                print(f"Epoch {epoch}/{config.epochs} step {step}: loss={avg_loss:.4f}")
+                running_loss = 0.0
+
+        scheduler.step()
+
+        if val_loader is not None:
+            val_accuracy = _evaluate(model, val_loader, device)
+            print(f"Epoch {epoch}: validation accuracy={val_accuracy:.3f}")
+            if val_accuracy > best_val_accuracy:
+                best_val_accuracy = val_accuracy
+                torch.save(model.state_dict(), config.output_dir / "best_model.pt")
+        else:
+            torch.save(model.state_dict(), config.output_dir / f"model_epoch_{epoch}.pt")
+
+    return model
+
+
+__all__ = ["TrainingConfig", "train_model"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,62 @@
+"""Tests covering the CNN pipeline for the COP solution."""
+
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+transforms = pytest.importorskip("torchvision.transforms")
+
+from cop_cnn.data import COPDataset, generate_synthetic_samples, metadata_to_tensor
+from cop_cnn.model import COPCNN
+from cop_cnn.train import TrainingConfig, train_model
+
+
+def test_dataset_and_model_forward(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    generate_synthetic_samples(data_dir, num_classes=2, samples_per_class=4, image_size=(32, 32), seed=1)
+
+    dataset = COPDataset(
+        data_dir,
+        transform=transforms.Compose([transforms.Resize((32, 32)), transforms.ToTensor()]),
+        metadata_transform=metadata_to_tensor,
+    )
+    sample = dataset[0]
+    assert sample["image"].shape == (3, 32, 32)
+    assert sample["metadata"].shape[-1] == 3
+
+    model = COPCNN(num_classes=2, metadata_dim=3)
+    batch = {
+        "image": torch.randn(2, 3, 32, 32),
+        "metadata": torch.randn(2, 3),
+        "label": torch.randint(0, 2, (2,)),
+    }
+    logits = model(batch["image"], batch["metadata"])
+    assert logits.shape == (2, 2)
+    loss = model.compute_loss(batch)
+    assert loss.item() > 0
+
+
+def test_training_loop_executes(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    generate_synthetic_samples(data_dir, num_classes=3, samples_per_class=6, image_size=(32, 32), seed=2)
+
+    config = TrainingConfig(
+        data_dir=data_dir,
+        num_classes=3,
+        metadata_dim=3,
+        image_size=(32, 32),
+        batch_size=4,
+        epochs=1,
+        learning_rate=1e-3,
+        validation_split=0.25,
+        num_workers=0,
+        output_dir=tmp_path / "artifacts",
+        device="cpu",
+        log_interval=1,
+        seed=123,
+    )
+
+    model = train_model(config)
+    assert isinstance(model, COPCNN)
+    assert (config.output_dir / "best_model.pt").exists()


### PR DESCRIPTION
## Summary
- add a reusable convolutional neural network architecture that fuses imagery with mission metadata for COP generation
- provide data ingestion utilities, synthetic dataset generator, configurable training loop, and inference engine
- document setup and workflows and cover the pipeline with pytest-based smoke tests

## Testing
- PYTHONPATH=src pytest -q *(skipped: torch not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0753c4b88333928872e9888fb638